### PR TITLE
詳細ページにコメント表示機能を実装しました。

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ReportStoreRequest;
 use App\Http\Requests\ReportUpdateRequest;
+use App\Models\Comment;
 use App\Models\Report;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -27,8 +28,8 @@ class ReportController extends Controller
 
     public function show(Report $report)
     {
-        $report = Report::with('comments.user')->findOrFail($report->id);
-        return view('report.show', compact('report'));
+        $comments = $report->comments()->with('user')->paginate(5);
+        return view('report.show', compact('report', 'comments'));
     }
 
     public function store(ReportStoreRequest $request)

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -27,6 +27,7 @@ class ReportController extends Controller
 
     public function show(Report $report)
     {
+        $report = Report::with('comments.user')->findOrFail($report->id);
         return view('report.show', compact('report'));
     }
 

--- a/resources/views/report/show.blade.php
+++ b/resources/views/report/show.blade.php
@@ -10,7 +10,7 @@
     </head>
 
     <body>
-        <div class="bg-gray-300 p-8 h-screen">
+        <div class=" p-8">
             <div class="w-3/5 m-auto mt-8">
                 <h1 class="text-2xl font-bold text-center mb-8">日報詳細</h1>
                 @if (session('message'))
@@ -63,6 +63,19 @@
                                     </x-primary-button>
                                 </form>
                             @endif
+                        </div>
+                    </div>
+                    <div class="bg-white p-8 mb-4 rounded-md shadow-lg">
+                        <h2 class="text-2xl font-bold mb-4">コメント一覧</h2>
+                        <div>
+                            @foreach ($report->comments as $comment)
+                                <div class="border p-4 mb-4">
+                                    <h3 class="mb-2 font-bold">投稿者: {{ $comment->user->name }}</h3>
+                                    <hr>
+                                    <p class="text-gray-700 mt-2">{{ $comment->body }}</p>
+                                    <p class="text-right">2024/01/10</p>
+                                </div>
+                            @endforeach
                         </div>
                     </div>
                 </div>

--- a/resources/views/report/show.blade.php
+++ b/resources/views/report/show.blade.php
@@ -67,16 +67,17 @@
                     </div>
                     <div class="bg-white p-8 mb-4 rounded-md shadow-lg">
                         <h2 class="text-2xl font-bold mb-4">コメント一覧</h2>
-                        <div>
-                            @foreach ($report->comments as $comment)
-                                <div class="border p-4 mb-4">
-                                    <h3 class="mb-2 font-bold">投稿者: {{ $comment->user->name }}</h3>
-                                    <hr>
-                                    <p class="text-gray-700 mt-2">{{ $comment->body }}</p>
-                                    <p class="text-right">2024/01/10</p>
-                                </div>
-                            @endforeach
-                        </div>
+                        @forelse ($comments as $comment)
+                            <div class="border p-4 mb-4">
+                                <h3 class="mb-2 font-bold">投稿者: {{ $comment->user->name }}</h3>
+                                <hr>
+                                <p class="text-gray-700 mt-2">{{ $comment->body }}</p>
+                                <p class="text-right">2024/01/10</p>
+                            </div>
+                        @empty
+                            <p>コメントはありません。</p>
+                        @endforelse
+                        {{ $comments->links() }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## やったこと

* 日報詳細ページにコメント表示機能を実装
* withメソッドを使用し、N+1問題を解決
* show.blade.phpにコメント表示

## やらないこと

* コメントの投稿、削除

## できるようになること（ユーザ目線）

* 日報詳細ページでコメントがあれば見れるようになりました。

## できなくなること（ユーザ目線）

* とくになし。

## 動作確認

* N+1問題が起きていないか、クエリの確認をしました。
* コメントの表示を確認しました。
