### PR TITLE
詳細ページにコメント投稿機能を実装しました。

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CommentStoreRequest;
+use Illuminate\Http\Request;
+use App\Models\Comment;
+use App\Models\Report;
+
+class CommentController extends Controller
+{
+    public function store(CommentStoreRequest $request, Report $report)
+    {
+        Comment::create([
+            'user_id' => auth()->id(),
+            'report_id' => $report->id,
+            'body' => $request->input('body'),
+        ]);
+
+        return redirect()->route('report.show', $report)->with('commentMessage', 'コメント投稿しました。');
+    }
+}

--- a/app/Http/Requests/CommentStoreRequest.php
+++ b/app/Http/Requests/CommentStoreRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'max:50'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'body.required' => ":attributeは必ず記入してください。",
+            'body.max' => ":attributeは50文字以内で記入してください。",
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'body' => 'コメント'
+        ];
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -9,6 +9,12 @@ class Comment extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'user_id',
+        'report_id',
+        'body',
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/resources/views/report/show.blade.php
+++ b/resources/views/report/show.blade.php
@@ -10,7 +10,7 @@
     </head>
 
     <body>
-        <div class="bg-gray-300 p-8 h-screen">
+        <div class="p-8">
             <div class="w-3/5 m-auto mt-8">
                 <h1 class="text-2xl font-bold text-center mb-8">日報詳細</h1>
                 @if (session('message'))
@@ -65,6 +65,27 @@
                             @endif
                         </div>
                     </div>
+                    <div class="w-full">
+                        <h3>コメント投稿</h3>
+                        @if (session('commentMessage'))
+                            <p class="text-red-500 font-bold">{{ session('commentMessage') }}</p>
+                        @endif
+                        <form action="{{ route('comment.store', $report) }}" method="POST">
+                            @csrf
+                            <div class="block w-full">
+                                @error('body')
+                                    <p class="text-red-600">{{ $message }}</p>
+                                @enderror
+                                <input type="text" name="body" id="body" class="w-full">
+                            </div>
+                            <div class="mt-2 flex justify-end">
+                                <x-primary-button>
+                                    投稿
+                                </x-primary-button>
+                            </div>
+                        </form>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CommentController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReportController;
 use Illuminate\Support\Facades\Route;
@@ -36,6 +37,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/report/{report}/edit', [ReportController::class, 'edit'])->name('report.edit');
     Route::put('/report/{report}', [ReportController::class, 'update'])->name('report.update');
     Route::delete('/report/{report}', [ReportController::class, 'destroy'])->name('report.destroy');
+    Route::post('/comment/{report}', [CommentController::class, 'store'])->name('comment.store');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## やったこと

* 日報詳細ページにコメント機能の実装
* コメント投稿時のフォームリクエスト作成
* 日報詳細ページにコメントフォームの追加

## やらないこと

* 日報の表示、削除
* 日報の表示は別のプルリクエストで実装済みです。

## できるようになること（ユーザ目線）

* 日報の詳細ページにコメントを投稿できるようになりました。

## 動作確認

* コメント投稿後データベースに保存されました。
* バリデーションエラー時のメッセージ表示も確認しました。
