### PR TITLE
現場テーブルの追加と関連する処理の修正

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -42,8 +42,8 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-            'employmentStatus' => UserConst::EMPLOYMENTSTATUS_DEFAULT_NUM,
-            'role' => UserConst::ROLE_DEFAULT_NUM,
+            'employmentStatus' => UserConst::EMPLOYMENTSTATUS_EMPLOYED,
+            'role' => UserConst::ROLE_NORMAL,
         ]);
 
         event(new Registered($user));

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ReportStoreRequest;
 use App\Http\Requests\ReportUpdateRequest;
 use App\Models\Report;
+use App\Models\Site;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -25,7 +26,8 @@ class ReportController extends Controller
     public function create()
     {
         $users = User::all();
-        return view('report.create', compact('users'));
+        $sites = Site::all();
+        return view('report.create', compact('users', 'sites'));
     }
 
     public function show(Report $report)
@@ -46,7 +48,7 @@ class ReportController extends Controller
 
         DB::transaction(function () use ($request, $path) {
             $report = Report::create([
-                'site_name' => $request->input('site_name'),
+                'site_id' => $request->input('site_id'),
                 'user_id' => auth()->id(),
                 'image_path' => $request->image ? $path : '',
                 'body' => $request->input('body'),
@@ -67,11 +69,13 @@ class ReportController extends Controller
         $this->authorize($report);
 
         $users = User::all();
+        $sites = Site::all();
+
         $reportUserId = [];
         foreach ($report->users as $user) {
             $reportUserId[] = $user->id;
         }
-        return view('report.edit', compact('report', 'users', 'reportUserId'));
+        return view('report.edit', compact('report', 'users', 'sites', 'reportUserId'));
     }
 
     public function update(ReportUpdateRequest $request, Report $report)
@@ -84,7 +88,7 @@ class ReportController extends Controller
             $path = $request->file('image')->store('images', 'public');
         }
         DB::transaction(function () use ($request, $report, $path) {
-            $report->site_name = $request->input('site_name');
+            $report->site_id = $request->input('site_id');
             $report->body = $request->input('body');
             $report->image_path = $request->image ? $path : $report->image_path;
             $report->working_day = $request->input('working_day');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -23,7 +23,6 @@ class UserController extends Controller
     public function edit(User $user)
     {
         $this->authorize($user);
-        dd($user);
         return view('user.edit', compact('user'));
     }
 

--- a/app/Http/Requests/ReportStoreRequest.php
+++ b/app/Http/Requests/ReportStoreRequest.php
@@ -22,7 +22,7 @@ class ReportStoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'site_name' => ['required', 'string', 'max:20'],
+            'site_id' => ['required', 'integer'],
             'image_path' => ['nullable', 'string', 'max:100'],
             'body' => ['required', 'max:500'],
             'user_id' => ['nullable', 'array'],
@@ -36,7 +36,7 @@ class ReportStoreRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'site_name' => '現場名',
+            'site_id' => '現場名',
             'body' => '業務内容',
             'working_day' => '作業日',
             'start_time' => '開始時間',

--- a/app/Http/Requests/ReportStoreRequest.php
+++ b/app/Http/Requests/ReportStoreRequest.php
@@ -36,7 +36,7 @@ class ReportStoreRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'site_id' => '現場名',
+            'site_id' => '現場',
             'body' => '業務内容',
             'working_day' => '作業日',
             'start_time' => '開始時間',

--- a/app/Http/Requests/ReportUpdateRequest.php
+++ b/app/Http/Requests/ReportUpdateRequest.php
@@ -36,7 +36,7 @@ class ReportUpdateRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'site_id' => '現場名',
+            'site_id' => '現場',
             'body' => '業務内容',
             'working_day' => '作業日',
             'start_time' => '開始時間',

--- a/app/Http/Requests/ReportUpdateRequest.php
+++ b/app/Http/Requests/ReportUpdateRequest.php
@@ -22,7 +22,7 @@ class ReportUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'site_name' => ['required', 'string', 'max:20'],
+            'site_id' => ['required', 'integer'],
             'image_path' => ['nullable', 'string', 'max:100'],
             'body' => ['required', 'max:500'],
             'user_id' => ['nullable', 'array'],
@@ -36,7 +36,7 @@ class ReportUpdateRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'site_name' => '現場名',
+            'site_id' => '現場名',
             'body' => '業務内容',
             'working_day' => '作業日',
             'start_time' => '開始時間',

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -46,9 +46,11 @@ class Report extends Model
         $reports = Report::when($reportDate, function (Builder $query, $reportDate) {
             $query->where('working_day', $reportDate);
         })->when($keyword, function (Builder $query, $keyword) {
-            $query->where('site_name', 'LIKE', "%$keyword%");
-        })->with('user')
-            ->orderByRaw('working_day desc, site_name asc, user_id asc')
+            $query->whereHas('sites', function (Builder $query) use ($keyword) {
+                $query->where('name', 'LIKE', "%$keyword%");
+            });
+        })->with('user', 'site')
+            ->orderBy('working_day', 'desc', 'site.name', 'asc', 'user_id', 'asc')
             ->paginate(10)
             ->appends(['report_date' => $reportDate, "keyword" => $keyword]);
 

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -36,6 +36,11 @@ class Report extends Model
         return $this->hasMany(Comment::class);
     }
 
+    public function site()
+    {
+        return $this->belongsTo(Site::class);
+    }
+
     public function searchReport(?string $reportDate, ?string $keyword): LengthAwarePaginator
     {
         $reports = Report::when($reportDate, function (Builder $query, $reportDate) {

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -12,7 +12,7 @@ class Report extends Model
     use HasFactory;
 
     protected $fillable = [
-        'site_name',
+        'site_id',
         'user_id',
         'image_path',
         'body',
@@ -46,7 +46,7 @@ class Report extends Model
         $reports = Report::when($reportDate, function (Builder $query, $reportDate) {
             $query->where('working_day', $reportDate);
         })->when($keyword, function (Builder $query, $keyword) {
-            $query->whereHas('sites', function (Builder $query) use ($keyword) {
+            $query->whereHas('site', function (Builder $query) use ($keyword) {
                 $query->where('name', 'LIKE', "%$keyword%");
             });
         })->with('user', 'site')

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Site extends Model
+{
+    use HasFactory;
+
+    public function reports()
+    {
+        return $this->hasMany(Reports::class);
+    }
+}

--- a/database/factories/ReportFactory.php
+++ b/database/factories/ReportFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\User;
+use App\Models\Site;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -19,7 +20,7 @@ class ReportFactory extends Factory
     public function definition(): array
     {
         return [
-            'site_name' => fake()->word(),
+            'site_id' => Site::first()->id,
             'user_id' => User::factory()->create()->id,
             'image_path' => '',
             'body' => fake()->realText(50),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Consts\UserConst;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -28,6 +29,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'employmentStatus' => 1,
+            'role' => UserConst::ROLE_NORMAL,
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];

--- a/database/migrations/2024_04_16_200324_create_sites_table.php
+++ b/database/migrations/2024_04_16_200324_create_sites_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('address');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sites');
+    }
+};

--- a/database/migrations/2024_04_16_202052_modify_reports_table.php
+++ b/database/migrations/2024_04_16_202052_modify_reports_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reports', function (Blueprint $table) {
+            $table->dropColumn('site_name');
+            $table->foreignId('site_id')->after('id')->constrained();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reports', function (Blueprint $table) {
+            $table->dropColumn('site_id');
+            $table->string('site_name')->after('id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            SiteSeeder::class,
             ReportSeeder::class,
             CommentSeeder::class,
         ]);

--- a/database/seeders/SiteSeeder.php
+++ b/database/seeders/SiteSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SiteSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('sites')->insert([
+            'name' => '高橋様邸',
+            'address' => '新潟市1丁目',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+        DB::table('sites')->insert([
+            'name' => '鈴木様邸',
+            'address' => '長岡市2丁目',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+        DB::table('sites')->insert([
+            'name' => '佐藤様邸',
+            'address' => '上越市3丁目',
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/resources/views/report/create.blade.php
+++ b/resources/views/report/create.blade.php
@@ -6,12 +6,15 @@
         <form action="{{ route('report.store') }}" method="POST" enctype="multipart/form-data">
             @csrf
             <div class="mb-4">
-                <label for="site_name" class="block text-sm font-semibold text-gray-600">現場名:</label>
-                @error('site_name')
+                <label for="site_id" class="block text-sm font-semibold text-gray-600">現場名:</label>
+                @error('site_id')
                     <p class="text-red-600">{{ $message }}</p>
                 @enderror
-                <input type="text" name="site_name" id="site_name" class="w-full p-2 border rounded-md"
-                    value="{{ old('site_name') }}">
+                <select name="site_id" id="site_id">
+                    @foreach ($sites as $site)
+                        <option value="{{ $site->id }}">{{ $site->name }}</option>
+                    @endforeach
+                </select>
             </div>
             <div class="mb-4">
                 <label for="working_day" class="block text-sm font-semibold text-gray-600">作業日:</label>

--- a/resources/views/report/create.blade.php
+++ b/resources/views/report/create.blade.php
@@ -6,7 +6,7 @@
         <form action="{{ route('report.store') }}" method="POST" enctype="multipart/form-data">
             @csrf
             <div class="mb-4">
-                <label for="site_id" class="block text-sm font-semibold text-gray-600">現場名:</label>
+                <label for="site_id" class="block text-sm font-semibold text-gray-600">現場:</label>
                 @error('site_id')
                     <p class="text-red-600">{{ $message }}</p>
                 @enderror

--- a/resources/views/report/edit.blade.php
+++ b/resources/views/report/edit.blade.php
@@ -7,7 +7,7 @@
             @csrf
             @method('PUT')
             <div class="mb-4">
-                <label for="site_name" class="block text-sm font-semibold text-gray-600">現場名:</label>
+                <label for="site_name" class="block text-sm font-semibold text-gray-600">現場:</label>
                 @error('site_id')
                     <p class="text-red-600">{{ $message }}</p>
                 @enderror

--- a/resources/views/report/edit.blade.php
+++ b/resources/views/report/edit.blade.php
@@ -8,11 +8,16 @@
             @method('PUT')
             <div class="mb-4">
                 <label for="site_name" class="block text-sm font-semibold text-gray-600">現場名:</label>
-                @error('site_name')
+                @error('site_id')
                     <p class="text-red-600">{{ $message }}</p>
                 @enderror
-                <input type="text" name="site_name" id="site_name" class="w-full p-2 border rounded-md"
-                    value="{{ old('site_name', $report->site_name) }}">
+                <select name="site_id" id="site_id">
+                    @foreach ($sites as $site)
+                        <option value="{{ $site->id }}" {{ $report->site->id === $site->id ? 'selected' : '' }}>
+                            {{ $site->name }}
+                        </option>
+                    @endforeach
+                </select>
             </div>
             <div class="mb-4">
                 <label for="working_day" class="block text-sm font-semibold text-gray-600">作業日:</label>

--- a/resources/views/report/index.blade.php
+++ b/resources/views/report/index.blade.php
@@ -49,7 +49,7 @@
                             {{ $report->site->name }}
                         </td>
                         <td class="py-2 px-4 border-b text-left font-bold">
-                            {{ $report->site->address }}
+                            {{ Str::limit($report->site->address, 10, '...') }}
                         </td>
                         <td class="py-2 px-4 border-b text-left font-bold">
                             {{ $report->user->name }}

--- a/resources/views/report/index.blade.php
+++ b/resources/views/report/index.blade.php
@@ -34,6 +34,7 @@
                 <tr class="text-sm md:text-base">
                     <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">日付</th>
                     <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">現場名</th>
+                    <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">住所</th>
                     <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">作業責任者</th>
                 </tr>
             </thead>
@@ -45,7 +46,10 @@
                             {{ $report->working_day }}
                         </td>
                         <td class="py-2 px-4 border-b text-left font-bold">
-                            {{ $report->site_name }}
+                            {{ $report->site->name }}
+                        </td>
+                        <td class="py-2 px-4 border-b text-left font-bold">
+                            {{ $report->site->address }}
                         </td>
                         <td class="py-2 px-4 border-b text-left font-bold">
                             {{ $report->user->name }}

--- a/resources/views/report/index.blade.php
+++ b/resources/views/report/index.blade.php
@@ -28,30 +28,30 @@
             <p class="text-red-500 font-bold">{{ session('message') }}
             </p>
         @endif
-        <table class="w-full
-                    m-auto border border-gray-600 bg-white">
+        <table class="w-full m-auto border border-gray-600 bg-white">
             <thead>
                 <tr class="text-sm md:text-base">
-                    <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">日付</th>
-                    <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">現場名</th>
-                    <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">住所</th>
-                    <th class="py-2 px-4 bg-blue-600 border-b text-white text-left">作業責任者</th>
+                    <th class="p-2 md:py-2 md:px-4 bg-blue-600 border-b text-white text-left">日付</th>
+                    <th class="p-2 md:py-2 md:px-4 bg-blue-600 border-b text-white text-left">現場名</th>
+                    <th class="p-2 md:py-2 md:px-4 bg-blue-600 border-b text-white text-left">住所</th>
+                    <th class="p-2 md:py-2 md:px-4 bg-blue-600 border-b text-white text-left">作業責任者</th>
                 </tr>
             </thead>
             <tbody>
                 @foreach ($reports as $index => $report)
                     <tr class="text-sm md:text-base hover:bg-gray-100 cursor-pointer {{ $index % 2 === 1 ? 'bg-blue-100' : '' }}"
                         onclick="location.href='{{ route('report.show', $report) }}'">
-                        <td class="py-2 px-4 border-b text-left font-bold">
+                        <td class="w-1/4 p-1 md:py-2 md:px-4 border-b text-left font-bold">
                             {{ $report->working_day }}
                         </td>
-                        <td class="py-2 px-4 border-b text-left font-bold">
+                        <td class="w-1/4 p-1 md:py-2 md:px-4 border-b text-left font-bold">
                             {{ $report->site->name }}
                         </td>
-                        <td class="py-2 px-4 border-b text-left font-bold">
-                            {{ Str::limit($report->site->address, 10, '...') }}
+                        <td
+                            class="w-1/4 p-1 md:py-2 md:px-4 border-b text-left font-bold max-w-0 overflow-hidden text-ellipsis whitespace-nowrap	">
+                            {{ $report->site->address }}
                         </td>
-                        <td class="py-2 px-4 border-b text-left font-bold">
+                        <td class="w-1/4 p-1 md:py-2 md:px-4 border-b text-left font-bold">
                             {{ $report->user->name }}
                         </td>
                     </tr>

--- a/resources/views/report/show.blade.php
+++ b/resources/views/report/show.blade.php
@@ -16,6 +16,7 @@
             </div>
         </div>
         <div class="mb-4">
+            <p class="md:text-base text-xs font-bold mb-2">住所:{{ $report->site->address }}</p>
             <div class="flex justify-start mb-2">
                 <p class="md:text-base text-xs">開始時間: {{ $report->start_time }}</p>
                 <p class="ml-4 md:text-base text-xs">終了時間: {{ $report->end_time }}</p>

--- a/resources/views/report/show.blade.php
+++ b/resources/views/report/show.blade.php
@@ -8,7 +8,7 @@
         @endif
         <div class="flex justify-between items-center mb-4 border-b-4 border-blue-300 pb-2">
             <h2 class="md:text-2xl text-base font-bold">
-                {{ $report->site_name }}
+                {{ $report->site->name }}
             </h2>
             <div class="text-right">
                 <h3 class="text-gray-500 md:text-base text-xs">{{ $report->working_day }}</h3>


### PR DESCRIPTION
## やったこと

* 現場テーブル(sites)の追加
* 現場のダミーデータ作成
* 現場と日報のリレーションの設定
* キーワード検索処理(searchReport)修正
* 日報一覧、詳細、登録、更新画面の修正
* 日報登録と更新時の現場名をセレクトボックスに変更

## やらないこと

* ダミーデータ以外での現場登録

## できるようになること（ユーザ目線）

* 日報登録時と更新時に、現場名を現場テーブルに登録してあるデータから選択するようになります

## できなくなること（ユーザ目線）

* 日報登録時と更新時に、現場テーブルにない現場の登録ができなくなります。

## 動作確認

* 日報登録時と更新時に、セレクトボックスから選択して正常に登録、更新されることを確認しました。
* キーワード検索で現場名を検索できることを確認しました。