### PR TITLE
予定登録、更新機能の修正

### DIFF
--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -29,19 +29,15 @@ class ScheduleController extends Controller
     public function create()
     {
         $users = User::all();
-        return view('schedule.create', compact('users'));
+        $sites = Site::all();
+        return view('schedule.create', compact('users', 'sites'));
     }
 
     public function store(ScheduleStoreRequest $request)
     {
         DB::transaction(function () use ($request) {
-            $site = Site::create([
-                'name' => $request->site_name,
-                'address' => $request->address,
-            ]);
-
             $schedule = Schedule::create([
-                'site_id' => $site->id,
+                'site_id' => $request->site_id,
                 'work_details' => $request->work_details,
                 'working_day' => $request->working_day,
             ]);

--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -57,14 +57,14 @@ class ScheduleController extends Controller
     public function edit(Schedule $schedule)
     {
         $users = User::all();
-        return view('schedule.edit', compact('schedule', 'users'));
+        $sites = Site::all();
+        return view('schedule.edit', compact('schedule', 'users', 'sites'));
     }
 
     public function update(ScheduleUpdateRequest $request, Schedule $schedule)
     {
         DB::transaction(function () use ($request, $schedule) {
-            $schedule->site->name = $request->input('site_name');
-            $schedule->site->address = $request->input('address');
+            $schedule->site_id = $request->input('site_id');
             $schedule->site->save();
 
             $schedule->work_details = $request->input('work_details');
@@ -74,7 +74,7 @@ class ScheduleController extends Controller
             $schedule->users()->sync($request->input('member_id'));
         });
 
-        return redirect()->route('schedule.show', $schedule)->with('message', '予定を登録しました。');
+        return redirect()->route('schedule.show', $schedule)->with('message', '予定を更新しました。');
     }
 
     public function destroy(Schedule $schedule)

--- a/app/Http/Requests/ScheduleStoreRequest.php
+++ b/app/Http/Requests/ScheduleStoreRequest.php
@@ -22,8 +22,7 @@ class ScheduleStoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'site_name' => ['required', 'string', 'max:20'],
-            'address' => ['required', 'string'],
+            'site_id' => ['required', 'string', 'exists:sites,id'],
             'member_id' => ['required', 'array'],
             'working_day' => ['required', 'date', 'after:today'],
             'work_details' => ['required', 'string', 'max:100'],
@@ -33,8 +32,7 @@ class ScheduleStoreRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'site_name' => '現場',
-            'address' => '住所',
+            'site_id' => '現場',
             'member_id' => 'メンバー',
             'working_day' => '作業日',
             'work_details' => '作業内容',

--- a/app/Http/Requests/ScheduleUpdateRequest.php
+++ b/app/Http/Requests/ScheduleUpdateRequest.php
@@ -22,8 +22,7 @@ class ScheduleUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'site_name' => ['required', 'string', 'max:20'],
-            'address' => ['required', 'string'],
+            'site_id' => ['required', 'string', 'exists:sites,id'],
             'member_id' => ['required', 'array'],
             'working_day' => ['required', 'date', 'after:today'],
             'work_details' => ['required', 'string', 'max:100'],
@@ -33,8 +32,7 @@ class ScheduleUpdateRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'site_name' => '現場',
-            'address' => '住所',
+            'site_id' => '現場',
             'member_id' => 'メンバー',
             'working_day' => '作業日',
             'work_details' => '作業内容',

--- a/resources/views/schedule/create.blade.php
+++ b/resources/views/schedule/create.blade.php
@@ -6,18 +6,13 @@
         <form action="{{ route('schedule.store') }}" method="POST" class="mb-8">
             @csrf
             <div class="mb-4">
-                <label for="site_name" class="block text-sm font-semibold text-gray-600">現場:</label>
-                <input type="text" name="site_name" id="site_name" class="w-full p-2 border rounded-md"
-                    value="{{ old('site_name') }}">
+                <label for="site_id" class="block text-sm font-semibold text-gray-600">現場:</label>
+                <select name="site_id" id="site_id">
+                    @foreach ($sites as $site)
+                        <option value="{{ $site->id }}">{{ $site->name }}</option>
+                    @endforeach
+                </select>
                 @error('site_name')
-                    <p class="text-red-600">{{ $message }}</p>
-                @enderror
-            </div>
-            <div class="mb-4">
-                <label for="address" class="block text-sm font-semibold text-gray-600">住所:</label>
-                <input type="text" name="address" id="address" class="w-full p-2 border rounded-md"
-                    value="{{ old('address') }}">
-                @error('address')
                     <p class="text-red-600">{{ $message }}</p>
                 @enderror
             </div>

--- a/resources/views/schedule/edit.blade.php
+++ b/resources/views/schedule/edit.blade.php
@@ -7,18 +7,14 @@
             @csrf
             @method('PATCH')
             <div class="mb-4">
-                <label for="site_name" class="block text-sm font-semibold text-gray-600">現場:</label>
-                <input type="text" name="site_name" id="site_name" class="w-full p-2 border rounded-md"
-                    value="{{ $schedule->site->name }}">
+                <label for="site_id" class="block text-sm font-semibold text-gray-600">現場:</label>
+                <select name="site_id" id="site_id">
+                    @foreach ($sites as $site)
+                        <option value="{{ $site->id }}" @selected($schedule->site->id === $site->id)>{{ $site->name }}
+                        </option>
+                    @endforeach
+                </select>
                 @error('site_name')
-                    <p class="text-red-600">{{ $message }}</p>
-                @enderror
-            </div>
-            <div class="mb-4">
-                <label for="address" class="block text-sm font-semibold text-gray-600">住所:</label>
-                <input type="text" name="address" id="address" class="w-full p-2 border rounded-md"
-                    value="{{ $schedule->site->address }}">
-                @error('address')
                     <p class="text-red-600">{{ $message }}</p>
                 @enderror
             </div>


### PR DESCRIPTION
## やったこと

* 予定登録時に現場をセレクトボックスから選択できるように変更
* 予定更新時に現場をセレクトボックスから選択できるように変更
* 予定登録、更新ページの修正
* 予定登録、更新時のバリデーションルールの修正

## やらないこと

* とくになし

## できるようになること（ユーザ目線）

* 予定登録と更新時に現場を選択するようになりました。

## できなくなること（ユーザ目線）

* 予定登録と更新時に新しい現場の登録ができなくなりました。

## 動作確認

* 予定の登録、更新が正常にできることを確認しました。